### PR TITLE
Reset custom runway config when runway selection dialog closes with OK

### DIFF
--- a/DelHel/CDelHel.cpp
+++ b/DelHel/CDelHel.cpp
@@ -338,6 +338,9 @@ void CDelHel::OnFlightPlanDisconnect(EuroScopePlugIn::CFlightPlan FlightPlan)
 
 void CDelHel::OnAirportRunwayActivityChanged()
 {
+	this->LogMessage("Runway selection dialog closed, no longer using custom runway config", "Config");
+	this->customRunwayConfig = "";
+
 	this->UpdateActiveAirports();
 }
 


### PR DESCRIPTION
Prevents controllers from changing runway config but not realising that custom runway config in Delhel is still active.

Solves the following scenario:

29/34 active, controller activates G2 custom config
29 active, delhel still uses G2, but 34 not active so behaves like 29er only, even though G2 is still selected
29/34 active again, controller assumes it now uses G1, but delhel still set to G2

This change removes any custom config if the runway dialog is closed using the OK button and prints a config log message informing the controller about this. If no change is desired use the Cancel button instead.